### PR TITLE
fix issue when delimiter was split and fragment was separate

### DIFF
--- a/lib/buftok.rb
+++ b/lib/buftok.rb
@@ -44,7 +44,7 @@ class BufferedTokenizer
       @tail = entities.pop
     end
 
-    entities
+    entities.map { |e| e.gsub(@delimiter, '') }
   end
 
   # Flush the contents of the input buffer, i.e. return the input buffer even though

--- a/test/test_buftok.rb
+++ b/test/test_buftok.rb
@@ -24,4 +24,12 @@ class TestBuftok < Test::Unit::TestCase
     assert_equal %w[bar<baz qux], tokenizer.extract('baz<>qux<>'.freeze)
     assert_equal '', tokenizer.flush
   end
+
+  def test_split_and_isolated_delimiter
+    tokenizer = BufferedTokenizer.new("\r\n".freeze)
+    assert_equal [], tokenizer.extract("foo\r".freeze)
+    assert_equal %w[foo], tokenizer.extract("\n".freeze)
+    assert_equal %w[bar], tokenizer.extract("bar\r\n".freeze)
+    assert_equal '', tokenizer.flush
+  end
 end


### PR DESCRIPTION
I ran into an issue using the twitter gem when listening to tweets. The problem is that every ~7-20k tweets listened to, it would buffer \n into its own line when trying to tokenize \r\n

So I would get output like:

```
"..."timestamp_ms\":\"1414093345229\"}\r",
 "\n",
 "{\"created}..."
```

and this would throw a JSON.parse exception.

![pastedgraphic-1](https://cloud.githubusercontent.com/assets/913889/4760733/61d0bd46-5af2-11e4-8ec5-19947205feff.png)

The CONTRIBUTE.md mentions a few rake tasks that don't seem to apply to this project, unless I'm missing something. I've added a test case and ran test cases and all passing. 

This is my first pull request to any open source project, hoping I did this correctly.
