### PR TITLE
Adds #size to BufferedTokenizer

### DIFF
--- a/lib/buftok.rb
+++ b/lib/buftok.rb
@@ -19,6 +19,14 @@ class BufferedTokenizer
     @trim = @delimiter.length - 1
   end
 
+  # Determine the size of the internal buffer.
+  #
+  # Size is not cached and is determined every time this method is called
+  # in order to optimize throughput for extract.
+  def size
+    @tail.length + @input.inject(0) { |total, input| total + input.length }
+  end
+
   # Extract takes an arbitrary string of input data and returns an array of
   # tokenized entities, provided there were any available to extract.  This
   # makes for easy processing of datagrams using a pattern like:

--- a/test/test_buftok.rb
+++ b/test/test_buftok.rb
@@ -24,4 +24,14 @@ class TestBuftok < Test::Unit::TestCase
     assert_equal %w[bar<baz qux], tokenizer.extract('baz<>qux<>'.freeze)
     assert_equal '', tokenizer.flush
   end
+
+  def test_size
+    tokenizer = BufferedTokenizer.new('<>'.freeze)
+    assert_equal [], tokenizer.extract('foo<'.freeze)
+    assert_equal 4, tokenizer.size
+    assert_equal %w[foo], tokenizer.extract('>bar<'.freeze)
+    assert_equal 4, tokenizer.size
+    assert_equal %w[bar<baz qux], tokenizer.extract('baz<>qux<>'.freeze)
+    assert_equal 0, tokenizer.size
+  end
 end


### PR DESCRIPTION
Allow external monitoring of the input buffer size if size constraint is necessary.

Fixes #6
